### PR TITLE
Azure SDK 2.3 support

### DIFF
--- a/Source/AzureFabricTask.Tests/FabricTests.cs
+++ b/Source/AzureFabricTask.Tests/FabricTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace AzureFabricTask.Tests
 {
     using System;
+    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using Xunit;
@@ -13,10 +14,23 @@
         }
 
         [Fact]
+        public void FabricInstallPathExists()
+        {
+            Assert.True(Directory.Exists(Fabric.DefaultInstallPath));
+        }
+
+        [Fact]
         public void FabricInitialize()
         {
             ProcessResult result = Fabric.Initialize();
             Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void EmulatorVersion()
+        {
+            Version version = Fabric.EmulatorVersion();
+            Assert.NotNull(version);
         }
 
         [Fact]

--- a/Source/AzureFabricTask/Fabric.cs
+++ b/Source/AzureFabricTask/Fabric.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Diagnostics;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using Microsoft.Win32;

--- a/Source/AzureFabricTask/Properties/AssemblyInfo.cs
+++ b/Source/AzureFabricTask/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Azure Fabric Task")]
 [assembly: AssemblyDescription("MSBuild task for managing the Windows Azure dev fabric.")]
 [assembly: Guid("44d08967-b442-4b7f-988e-57d51becfd7e")]
+[assembly: InternalsVisibleTo("AzureFabricTask.Tests")]


### PR DESCRIPTION
Checks the registry for the emulator version. If greater than 2.3 bootstraps emulator with current file conventions (e.g. devfabric/DFInit.exe vs devstore/DSInit.exe) and updated command arguments. Otherwise falls back to legacy.
